### PR TITLE
Time events are now broadcast, to communicate to other parts of the game.

### DIFF
--- a/StardewValley/Source/StardewValley/EventSystem.h
+++ b/StardewValley/Source/StardewValley/EventSystem.h
@@ -1,10 +1,18 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+/*****************************************************************
+ * \file   EventSystem.h
+ * \brief  The EventSystem. Use for communication between different parts.
+ * 
+ * \author 4_of_Diamonds
+ * \date   November 2024
+ *********************************************************************/
 
 #pragma once
 
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "EventSystem.generated.h"
+
+DECLARE_MULTICAST_DELEGATE(FMulticastDelegate);
 
 /**
  * 
@@ -13,5 +21,15 @@ UCLASS()
 class STARDEWVALLEY_API UEventSystem : public UGameInstanceSubsystem
 {
 	GENERATED_BODY()
-	
+public:
+	FMulticastDelegate OnEarlyMorningBegin;
+	FMulticastDelegate OnMorningBegin;
+	FMulticastDelegate OnNoonBegin;
+	FMulticastDelegate OnAfternoonBegin;
+	FMulticastDelegate OnEveningBegin;
+	FMulticastDelegate OnNightBegin;
+	FMulticastDelegate OnSpringBegin;
+	FMulticastDelegate OnSummerBegin;
+	FMulticastDelegate OnAutumnBegin;
+	FMulticastDelegate OnWinterBegin;
 };

--- a/StardewValley/Source/StardewValley/StardewValleyGameInstance.h
+++ b/StardewValley/Source/StardewValley/StardewValleyGameInstance.h
@@ -13,5 +13,5 @@ UCLASS()
 class STARDEWVALLEY_API UStardewValleyGameInstance : public UGameInstance
 {
 	GENERATED_BODY()
-	
+
 };

--- a/StardewValley/Source/StardewValley/TimeSystem.cpp
+++ b/StardewValley/Source/StardewValley/TimeSystem.cpp
@@ -1,7 +1,13 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
+/****************************************************************
+ * \file   TimeSystem.cpp
+ * \brief  The implementation of the time system
+ * 
+ * \author 4_of_Diamonds
+ * \date   November 2024
+ *********************************************************************/
 
 #include "TimeSystem.h"
+#include "EventSystem.h"
 #include <stdexcept>
 
 void UTimeSystem::Initialize(FSubsystemCollectionBase& Collection)
@@ -9,8 +15,8 @@ void UTimeSystem::Initialize(FSubsystemCollectionBase& Collection)
 	Super::Initialize(Collection);
 	FTimerDelegate timer_delegate;
 	timer_delegate.BindUObject(this, &UTimeSystem::TimeFlow);
-	UE_LOG(LogTemp, Warning, TEXT("Time now is Season"));
 	GetGameInstance()->GetWorld()->GetTimerManager().SetTimer(timer_handle_, timer_delegate, 1.0f, true);
+
 }
 
 void UTimeSystem::Deinitialize()
@@ -48,11 +54,65 @@ void UTimeSystem::Flow(const int32 kElapsedTimeInMinutes)
 	int final_season = static_cast<int>(season_) + elapsed_seasons;
 	season_ = static_cast<Season>(final_season % kSeasonsNum);
 	day_in_season_ = day_in_season_ % kDaysInSeason;
+	if(day_in_season_ == 0)day_in_season_ = 1;
 }
 
 void UTimeSystem::TimeFlow()
 {
 	//UE_LOG(LogTemp, Warning, TEXT("Called"));
 	Flow(1);
+
+	//Broadcast events on key times
+	if (minute_ == 0 && hour_ == 2)
+	{
+		if(GetGameInstance()->GetSubsystem<UEventSystem>()->OnEarlyMorningBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnEarlyMorningBegin.Broadcast();
+	}
+	else if (minute_ == 0 && hour_ == 6)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnMorningBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnMorningBegin.Broadcast();
+	}
+	else if (minute_ == 0 && hour_ == 10)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnNoonBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnNoonBegin.Broadcast();
+	}
+	else if (minute_ == 0 && hour_ == 14)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnAfternoonBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnAfternoonBegin.Broadcast();
+	}
+	else if (minute_ == 0 && hour_ == 18)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnEveningBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnEveningBegin.Broadcast();
+	}
+	else if (minute_ == 0 && hour_ == 22)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnNightBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnNightBegin.Broadcast();
+	}
+
+	if (season_ == Season::Spring && day_in_season_ == 1 && hour_ == 0 && minute_ == 0)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnSpringBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnSpringBegin.Broadcast();
+	}
+	else if (season_ == Season::Summer && day_in_season_ == 1 && hour_ == 0 && minute_ == 0)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnSummerBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnSummerBegin.Broadcast();
+	}
+	else if (season_ == Season::Autumn && day_in_season_ == 1 && hour_ == 0 && minute_ == 0)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnAutumnBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnAutumnBegin.Broadcast();
+	}
+	else if (season_ == Season::Winter && day_in_season_ == 1 && hour_ == 0 && minute_ == 0)
+	{
+		if (GetGameInstance()->GetSubsystem<UEventSystem>()->OnWinterBegin.IsBound())
+			GetGameInstance()->GetSubsystem<UEventSystem>()->OnWinterBegin.Broadcast();
+	}
 	UE_LOG(LogTemp, Warning, TEXT("Time now is Season: %d, Day: %d, Hour: %d, minute: %d"), static_cast<int>(get_season()), get_day_in_season(), get_hour(), get_minute());
 }

--- a/StardewValley/Source/StardewValley/TimeSystem.h
+++ b/StardewValley/Source/StardewValley/TimeSystem.h
@@ -32,7 +32,7 @@ private:
 		Autumn,
 		Winter
 	};
-	const int kDaysInSeason = 30;
+	const int kDaysInSeason = 31;
 	const int kHoursInDay = 24;
 	const int kMinutesInHour = 60;
 	const int kSeasonsNum = 4;


### PR DESCRIPTION
Debug: Have day_in_season begin from 1 instead of 0.
Add following time-related event (multicast delegates): 
OnEarlyMorningBegin
OnMorningBegin
OnNoonBegin
OnAfternoonBegin
OnEveningBegin
OnNightBegin
OnSpringBegin
OnSummerBegin
OnAutumnBegin
OnWinterBegin
to communicate with other part of the game.
EventSystem begins to be put into use.